### PR TITLE
Update repository name (MACE -> MACESW)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ apptainer shell ./rgb.sif
 Then, in the container shell, clone and build MACESW:
 ```bash
 git clone https://github.com/zhao-shihan/MACESW.git
-cd MACE
+cd MACESW
 mkdir build && cd build
 cmake ..
 make -j8


### PR DESCRIPTION
This pull request updates the `README.md` to reflect a repository name change from `MACE` to `MACESW`. The main adjustments involve updating all badges, URLs, and instructions to use the new repository name, ensuring documentation accuracy and consistency.

Repository and badge updates:

* Updated all badge URLs and references from `MACE` to `MACESW` in the `README.md` to reflect the new repository name and location.

Documentation instructions:

* Changed the git clone command in the setup instructions to use `MACESW` instead of `MACE`, ensuring users clone the correct repository.