### PR TITLE
Avoid duplicated CI triggers

### DIFF
--- a/.github/workflows/build-with-clang.yml
+++ b/.github/workflows/build-with-clang.yml
@@ -9,14 +9,6 @@ on:
       - "MACE.c\\+\\+"
       - "**/CMakeLists.txt"
       - "**.cmake"
-  pull_request:
-    branches: ["**"]
-    paths:
-      - ".github/workflows/build-with-clang.yml"
-      - "src/**"
-      - "MACE.c\\+\\+"
-      - "**/CMakeLists.txt"
-      - "**.cmake"
 
 jobs:
   build-with-clang:

--- a/.github/workflows/build-with-gcc.yml
+++ b/.github/workflows/build-with-gcc.yml
@@ -9,14 +9,6 @@ on:
       - "MACE.c\\+\\+"
       - "**/CMakeLists.txt"
       - "**.cmake"
-  pull_request:
-    branches: ["**"]
-    paths:
-      - ".github/workflows/build-with-gcc.yml"
-      - "src/**"
-      - "MACE.c\\+\\+"
-      - "**/CMakeLists.txt"
-      - "**.cmake"
 
 jobs:
   build-with-gcc:

--- a/.github/workflows/regression-test-with-clang.yml
+++ b/.github/workflows/regression-test-with-clang.yml
@@ -1,15 +1,6 @@
 name: Regression test (AMD64 GNU/Linux Clang)
 
 on:
-  push:
-    branches: ["main", "rc"]
-    paths:
-      - ".github/workflows/regression-test-with-clang.yml"
-      - "src/**"
-      - "test/**"
-      - "MACE.c\\+\\+"
-      - "**/CMakeLists.txt"
-      - "**.cmake"
   pull_request:
     branches: ["main", "rc"]
     paths:

--- a/.github/workflows/regression-test-with-gcc.yml
+++ b/.github/workflows/regression-test-with-gcc.yml
@@ -1,15 +1,6 @@
 name: Regression test (AMD64 GNU/Linux GCC)
 
 on:
-  push:
-    branches: ["main", "rc"]
-    paths:
-      - ".github/workflows/regression-test-with-gcc.yml"
-      - "src/**"
-      - "test/**"
-      - "MACE.c\\+\\+"
-      - "**/CMakeLists.txt"
-      - "**.cmake"
   pull_request:
     branches: ["main", "rc"]
     paths:

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -11,16 +11,6 @@ on:
       - "**.cmake"
       - ".clang-format"
       - ".clang-tidy"
-  pull_request:
-    branches: ["**"]
-    paths:
-      - ".github/workflows/static-code-analysis.yml"
-      - "src/**"
-      - "MACE.c\\+\\+"
-      - "**/CMakeLists.txt"
-      - "**.cmake"
-      - ".clang-format"
-      - ".clang-tidy"
 
 jobs:
   clang-format-tidy:


### PR DESCRIPTION
## Summary
This pull request updates the GitHub Actions workflow triggers to streamline CI/CD processes. The main change is the removal of the `pull_request` event trigger from several build and static analysis workflows, and the removal of the `push` event trigger from regression test workflows. Now, regression tests run only on pull requests targeting specific branches, and build/static analysis workflows are no longer triggered by pull requests.

Workflow trigger updates:

**Build and static analysis workflows**
* Removed the `pull_request` event trigger from `.github/workflows/build-with-clang.yml`, `.github/workflows/build-with-gcc.yml`, and `.github/workflows/static-code-analysis.yml`, so these workflows will no longer run on pull requests. [[1]](diffhunk://#diff-21c2430cfe3082a4584972fe4517da9954f938e72585e90345e4b51b5f4f69f7L12-L19) [[2]](diffhunk://#diff-7548585ec91e93077ae1e1572b2dfb9aa8a04e0099ec33468e82bd9de86dd80cL12-L19) [[3]](diffhunk://#diff-050e2f79a303e5bc2d272a40cfc62ff6cae70797e3c94cf6a93e4e5488ab9d27L14-L23)

**Regression test workflows**
* Removed the `push` event trigger from `.github/workflows/regression-test-with-clang.yml` and `.github/workflows/regression-test-with-gcc.yml`, so regression tests now only run on pull requests to the `main` and `rc` branches. [[1]](diffhunk://#diff-8fd0a388e5c2b007c23e5b01639bf622cd8f8f3252478e2c7a1a8bfa263ec652L4-L12) [[2]](diffhunk://#diff-ba4b603a75efd2afa11faab08759a98b1cdc09784a1c076f2415ef8970dd30a9L4-L12)

## Type of change
- CI / tooling

## Checklist before requesting review
- [x] I have read the [contributing guidelines](https://github.com/zhao-shihan/MACESW/blob/main/CONTRIBUTING.md)
- [x] The PR targets the `main` branch.
- [x] I linked related issues and provided context in the PR description.
- [x] My code follows the [coding style guide](https://github.com/zhao-shihan/MACESW/blob/main/STYLE_GUIDE.md) and linting rules.
- [x] I added/updated unit tests where applicable.
- [x] I updated relevant documentation (README, Doxygen, or design docs).
- [x] I ran the test-suite locally and all tests pass.
- [x] All CI checks pass.

## Reviewer notes
None.

## Additional information
None.
