### PR TITLE
Add security policy document for reporting vulnerabilities

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+Thank you for taking the time to help keep the MACESW project secure. This document explains how to responsibly report security vulnerabilities and how we handle reports.
+
+## Reporting a vulnerability
+
+**Preferred method:**
+- **Create a GitHub Security Advisory for this repository: https://github.com/zhao-shihan/MACESW/security/advisories/new**
+
+When reporting, please include as much of the following as you can:
+- Affected component(s) and version(s) (commit SHA, tag, or branch)
+- A concise description of the issue and potential impact
+- Steps to reproduce (minimal reproduction is extremely helpful)
+- Proof-of-concept code or test case, if available
+- Any suggested remediation or mitigation
+- Your contact information and how you prefer to be credited (or request anonymity)
+
+If you are unable to use the GitHub Security Advisory workflow for any reason, please contact the project owner privately, or open an issue but avoid including any exploit details until a fix is available.
+
+## Supported releases
+
+We consider the main branch and the latest tagged release as supported. If you report a vulnerability, please indicate the affected versions (tags or commit SHAs). We will prioritize fixes for the current stable release and the main branch.
+
+## Out-of-scope
+
+Security issues in third-party dependencies should be reported to the maintainers of those dependencies as well as here when appropriate. Supply-chain attacks or vulnerabilities in external build tools should be reported upstream in their respective projects.
+
+## Credit
+
+Unless you request otherwise, we will credit people who report security issues in release notes or advisories.
+
+## Legal
+
+We encourage security researchers to follow responsible disclosure practices. We will not pursue legal action against good-faith security research that follows the above guidance. We expect reporters to avoid intentionally destructive behavior and to avoid accessing or modifying data not needed to demonstrate the issue.
+
+Thank you for helping improve the security of MACESW.


### PR DESCRIPTION
## Summary
This pull request adds a new security policy for the MACESW project to guide contributors and users on how to responsibly report security vulnerabilities. The policy outlines preferred reporting methods, supported releases, out-of-scope issues, crediting reporters, and legal considerations.

Security policy introduction:

* Added a new `SECURITY.md` file detailing how to report vulnerabilities, including the use of GitHub Security Advisories and required information for reports.
* Specified which releases are supported for security fixes and how reporters should indicate affected versions.

Scope and legal guidance:

* Clarified that issues in third-party dependencies or supply-chain vulnerabilities should be reported upstream as well as to this project when appropriate.
* Outlined how reporters will be credited and provided assurance of no legal action for good-faith security research following the policy.

## Type of change
- Documentation update

## Checklist before requesting review
- [x] I have read the [contributing guidelines](https://github.com/zhao-shihan/MACESW/blob/main/CONTRIBUTING.md)
- [x] The PR targets the `main` branch.
- [x] I linked related issues and provided context in the PR description.
- [x] My code follows the [coding style guide](https://github.com/zhao-shihan/MACESW/blob/main/STYLE_GUIDE.md) and linting rules.
- [x] I added/updated unit tests where applicable.
- [x] I updated relevant documentation (README, Doxygen, or design docs).
- [x] I ran the test-suite locally and all tests pass.
- [x] All CI checks pass.

## Reviewer notes
None.

## Additional information
None.
