### PR TITLE
 Update nightly tagging format

### DIFF
--- a/.github/workflows/nightly-tagging.yml
+++ b/.github/workflows/nightly-tagging.yml
@@ -236,7 +236,7 @@ jobs:
 
           BASE_VERSION="${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}"
           COMMIT_SHA_SHORT=$(git rev-parse --short=7 rc)
-          TODAY_TAG="v${BASE_VERSION}-nightly~$(date +'%Y%m%d')+git${COMMIT_SHA_SHORT}"
+          TODAY_TAG="v${BASE_VERSION}~nightly$(date +'%Y%m%d')+git${COMMIT_SHA_SHORT}"
           echo "today_tag=${TODAY_TAG}" >> $GITHUB_OUTPUT
           echo "Today's tag would be: ${TODAY_TAG}"
 


### PR DESCRIPTION
## Summary
This pull request updates the nightly tagging workflow to use a new tag format for nightly builds. The changes focus on standardizing the tag naming convention and updating the logic to match the new format.

Tag format update:

* Changed the nightly tag format from `v{BASE_VERSION}-nightly.{date}+{SHA}` to `v{BASE_VERSION}~nightly{date}+git{SHA}` in `.github/workflows/nightly-tagging.yml` to improve consistency and clarity.

Tag matching logic update:

* Updated the `git tag` search pattern from `'v*-nightly.*'` to `'v*~nightly*'` in `.github/workflows/nightly-tagging.yml` to match the new nightly tag format.

## Type of change
- CI / tooling
