### PR TITLE
Update clang-tidy configuration to include small Eigen matrix types

### DIFF
--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -12,7 +12,7 @@ on:
       - "**/CMakeLists.txt"
       - "**.cmake"
       - ".clang-format"
-      - ".clang-tidy"
+      - "tooling/clang-tidy*"
 
   pull_request:
     branches:

--- a/tooling/clang-tidy.in
+++ b/tooling/clang-tidy.in
@@ -174,7 +174,7 @@ CheckOptions:
   - key: modernize-use-auto.RemoveStars
     value: true
   - key: performance-unnecessary-value-param.AllowedTypes
-    value: CLHEP::Hep2Vector;G4TwoVector;CLHEP::Hep3Vector;G4ThreeVector;CLHEP::HepLorentzVector;G4LorentzVector;Eigen::Vector2.*$;Eigen::Vector3.*$;Eigen::Vector4.*$
+    value: CLHEP::Hep2Vector;G4TwoVector;CLHEP::Hep3Vector;G4ThreeVector;CLHEP::HepLorentzVector;G4LorentzVector;Eigen::Vector2.*$;Eigen::Vector3.*$;Eigen::Vector4.*$;Eigen::RowVector2.*$;Eigen::RowVector3.*$;Eigen::RowVector4.*$;Eigen::Matrix2.*$
   - key: readability-function-cognitive-complexity.Threshold
     value: 50
   - key: readability-identifier-naming.ClassCase


### PR DESCRIPTION
## Summary
Update clang-tidy configuration to include small Eigen matrix types

## Type of change
- New feature (non-breaking change which adds functionality)

## Checklist before requesting review
- [x] I have read the [contributing guidelines](https://github.com/zhao-shihan/MACESW/blob/main/CONTRIBUTING.md)
- [x] The PR targets the `main` branch.
- [x] I linked related issues and provided context in the PR description.
- [x] My code follows the [coding style guide](https://github.com/zhao-shihan/MACESW/blob/main/STYLE_GUIDE.md) and linting rules.
- [x] I added/updated unit tests where applicable.
- [x] I updated relevant documentation (README, Doxygen, or design docs) where applicable.
- [x] I ran the test-suite locally and all tests pass if applicable.
- [x] All CI checks pass.
