### PR TITLE
Replace all instances of "FastField" with "NominalField"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,8 +82,8 @@ option(MACESW_USE_SHARED_MSVC_RT "Select the MSVC runtime library for use (MSVC 
 option(MACESW_WERROR "Treat MACESW compilation warnings as errors." OFF)
 option(MACESW_WITH_DEBUG_INFO "Always add debugging information" OFF)
 set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "Build using shared libraries")
-set(MACESW_BUILTIN_MACESW_OFFLINE_DATA_VERSION 0.25.103013 CACHE STRING "Set built-in offline data version (if required).")
-set(MACESW_BUILTIN_MACESW_TEST_DATA_VERSION 0.25.10301318 CACHE STRING "Set built-in test data version (if required).")
+set(MACESW_BUILTIN_MACESW_OFFLINE_DATA_VERSION 0.26.010616 CACHE STRING "Set built-in offline data version (if required).")
+set(MACESW_BUILTIN_MACESW_TEST_DATA_VERSION 0.26.010616 CACHE STRING "Set built-in test data version (if required).")
 set(MACESW_BUILTIN_MUSTARD_VERSION 0.25.1222 CACHE STRING "Set built-in Mustard version (if required).")
 set(MACESW_BUILTIN_PMP_VERSION 3.0.0 CACHE STRING "Set built-in pmp version (if required).")
 

--- a/README.md
+++ b/README.md
@@ -120,13 +120,16 @@ For advanced users or developers building from source or contributing to MACESW:
 以下依赖是可选的。如果在配置过程中在您的系统上未找到它们，CMake 将自动下载并构建它们。  
 The following dependencies are optional. If they are not found on your system during configuration, CMake will automatically download and build them.
 
-| 库 Library                                                                      | 版本 Version  | 描述 Description                                                                                                       |
-| :------------------------------------------------------------------------------ | :------------ | :--------------------------------------------------------------------------------------------------------------------- |
-| [**macesw_offline_data**](https://code.ihep.ac.cn/zhaoshh7/macesw_offline_data) | 0.25.103013   | MACESW 离线数据 / MACESW offline data                                                                                  |
-| [**macesw_test_data**](https://code.ihep.ac.cn/zhaoshh7/macesw_test_data)       | 0.25.10301318 | MACESW 测试数据 / MACESW test data                                                                                     |
-| [**Mustard**](https://github.com/zhao-shihan/Mustard)                           | ≥ 0.25.1222   | 一个现代的、高性能的高能物理实验离线软件框架 / A modern, high-performance offline software framework for HEP experiments |
-| [**PMP Library**](https://www.pmp-library.org/)                                 | ≥ 3.0.0       | 多边形网格处理库 / The Polygon Mesh Processing Library                                                                 |
-| [**zhao-shihan/GenFit**](https://github.com/zhao-shihan/GenFit)                 | main          | 一个通用的径迹拟合工具包 / A generic track-fitting toolkit                                                             |
+| 库 Library                                                      | 版本 Version | 描述 Description                                                                                                         |
+| :-------------------------------------------------------------- | :----------- | :----------------------------------------------------------------------------------------------------------------------- |
+| [**Mustard**](https://github.com/zhao-shihan/Mustard)           | ≥ 0.25.1222  | 一个现代的、高性能的高能物理实验离线软件框架 / A modern, high-performance offline software framework for HEP experiments |
+| [**PMP Library**](https://www.pmp-library.org/)                 | ≥ 3.0.0      | 多边形网格处理库 / The Polygon Mesh Processing Library                                                                   |
+| [**zhao-shihan/GenFit**](https://github.com/zhao-shihan/GenFit) | main         | 一个通用的径迹拟合工具包 / A generic track-fitting toolkit                                                               |
+
+| 数据 Data           | 版本 Version | 描述 Description                      |
+| :------------------ | :----------- | :------------------------------------ |
+| macesw_offline_data | 0.26.010616  | MACESW 离线数据 / MACESW offline data |
+| macesw_test_data    | 0.26.010616  | MACESW 测试数据 / MACESW test data    |
 
 ## 引用 / Citation
 

--- a/cmake/LookForMACEOfflineData.cmake
+++ b/cmake/LookForMACEOfflineData.cmake
@@ -17,7 +17,7 @@
 
 message(STATUS "Looking for macesw_offline_data")
 
-set(MACESW_MACESW_OFFLINE_DATA_MINIMUM_REQUIRED 0.25.103013)
+set(MACESW_MACESW_OFFLINE_DATA_MINIMUM_REQUIRED 0.26.010616)
 
 if(NOT MACESW_BUILTIN_MACESW_OFFLINE_DATA)
     find_package(macesw_offline_data ${MACESW_MACESW_OFFLINE_DATA_MINIMUM_REQUIRED})
@@ -36,7 +36,7 @@ if(MACESW_BUILTIN_MACESW_OFFLINE_DATA)
     endif()
     # set download dest and URL
     set(MACESW_BUILTIN_MACESW_OFFLINE_DATA_SRC_DIR "${MACESW_PROJECT_3RDPARTY_DIR}/macesw_offline_data-v${MACESW_BUILTIN_MACESW_OFFLINE_DATA_VERSION}")
-    set(MACESW_BUILTIN_MACESW_OFFLINE_DATA_URL "https://code.ihep.ac.cn/zhaoshh7/macesw_offline_data/-/archive/v${MACESW_BUILTIN_MACESW_OFFLINE_DATA_VERSION}/macesw_offline_data-v${MACESW_BUILTIN_MACESW_OFFLINE_DATA_VERSION}.tar.gz")
+    set(MACESW_BUILTIN_MACESW_OFFLINE_DATA_URL "https://github.com/MACESW-LFS/macesw_offline_data/archive/refs/tags/v${MACESW_BUILTIN_MACESW_OFFLINE_DATA_VERSION}.tar.gz")
     # reuse or download
     include(FetchContent)
     if(EXISTS "${MACESW_BUILTIN_MACESW_OFFLINE_DATA_SRC_DIR}/CMakeLists.txt")

--- a/cmake/LookForMACETestData.cmake
+++ b/cmake/LookForMACETestData.cmake
@@ -17,7 +17,7 @@
 
 message(STATUS "Looking for macesw_test_data")
 
-set(MACESW_MACESW_TEST_DATA_MINIMUM_REQUIRED 0.25.10301318)
+set(MACESW_MACESW_TEST_DATA_MINIMUM_REQUIRED 0.26.010616)
 
 if(NOT MACESW_BUILTIN_MACESW_TEST_DATA)
     find_package(macesw_test_data ${MACESW_MACESW_TEST_DATA_MINIMUM_REQUIRED})
@@ -36,7 +36,7 @@ if(MACESW_BUILTIN_MACESW_TEST_DATA)
     endif()
     # set download dest and URL
     set(MACESW_BUILTIN_MACESW_TEST_DATA_SRC_DIR "${MACESW_PROJECT_3RDPARTY_DIR}/macesw_test_data-v${MACESW_BUILTIN_MACESW_TEST_DATA_VERSION}")
-    set(MACESW_BUILTIN_MACESW_TEST_DATA_URL "https://code.ihep.ac.cn/zhaoshh7/macesw_test_data/-/archive/v${MACESW_BUILTIN_MACESW_TEST_DATA_VERSION}/macesw_test_data-v${MACESW_BUILTIN_MACESW_TEST_DATA_VERSION}.tar.gz")
+    set(MACESW_BUILTIN_MACESW_TEST_DATA_URL "https://github.com/MACESW-LFS/macesw_test_data/archive/refs/tags/v${MACESW_BUILTIN_MACESW_TEST_DATA_VERSION}.tar.gz")
     # reuse or download
     include(FetchContent)
     if(EXISTS "${MACESW_BUILTIN_MACESW_TEST_DATA_SRC_DIR}/CMakeLists.txt")

--- a/src/app/generator/MACE/GenBkgM2ENNE/GenBkgM2ENNE.c++
+++ b/src/app/generator/MACE/GenBkgM2ENNE/GenBkgM2ENNE.c++
@@ -76,7 +76,7 @@ auto GenBkgM2ENNE::Main(int argc, char* argv[]) const -> int {
     if (cli["--mace-bias"] == true) {
         const auto& cdc{Detector::Description::CDC::Instance()};
         const auto& ttc{Detector::Description::TTC::Instance()};
-        const auto mmsB{Detector::Description::MMSField::Instance().FastField()};
+        const auto mmsB{Detector::Description::MMSField::Instance().NominalField()};
         generator.Acceptance([outPxyCut = (ttc.Radius() / 2) * mmsB * c_light,
                               cosCut = 1 / muc::hypot(2 * cdc.GasOuterRadius() / cdc.GasOuterLength(), 1.),
                               epEkCut = cli->get<double>("--ep-ek-soft-upper-bound"),

--- a/src/app/generator/MACE/GenM2ENNEE/GenM2ENNEE.c++
+++ b/src/app/generator/MACE/GenM2ENNEE/GenM2ENNEE.c++
@@ -79,7 +79,7 @@ auto GenM2ENNEE::Main(int argc, char* argv[]) const -> int {
     if (cli["--mace-bias"] == true) {
         const auto& cdc{Detector::Description::CDC::Instance()};
         const auto& ttc{Detector::Description::TTC::Instance()};
-        const auto mmsB{Detector::Description::MMSField::Instance().FastField()};
+        const auto mmsB{Detector::Description::MMSField::Instance().NominalField()};
         generator.Acceptance([inPxyCut = (cdc.GasInnerRadius() / 2) * mmsB * c_light,
                               outPxyCut = (ttc.Radius() / 2) * mmsB * c_light,
                               cosCut = 1 / muc::hypot(2 * cdc.GasOuterRadius() / cdc.GasOuterLength(), 1.),

--- a/src/app/simulation/MACE/SimMACE/scripts/SimMACE.yaml
+++ b/src/app/simulation/MACE/SimMACE/scripts/SimMACE.yaml
@@ -87,7 +87,7 @@ ECAL:
 ECALField:
   Radius: 600
   Length: 1000
-  FastField: 0.0001
+  NominalField: 0.0001
 ECALMagnet:
   InnerRadius: 500
   OuterRadius: 550
@@ -121,7 +121,7 @@ MMSBeamPipe:
 MMSField:
   Radius: 650
   Length: 2200
-  FastField: 9.9999999999999991e-05
+  NominalField: 9.9999999999999991e-05
 MMSMagnet:
   InnerRadius: 550
   OuterRadius: 600
@@ -151,7 +151,7 @@ Solenoid:
   ReferenceCoilSpacing: 30
   FieldRadius: 130
   MaterialName: G4_Cu
-  FastField: 9.9999999999999991e-05
+  NominalField: 9.9999999999999991e-05
 TTC:
   Length: 70
   WidthDown: 30

--- a/src/app/simulation/MACE/SimMMS/scripts/SimMMS.yaml
+++ b/src/app/simulation/MACE/SimMMS/scripts/SimMMS.yaml
@@ -35,7 +35,7 @@ MMSBeamPipe:
 MMSField:
   Radius: 610
   Length: 2200
-  FastField: 9.9999999999999991e-05
+  NominalField: 9.9999999999999991e-05
 MMSMagnet:
   InnerRadius: 550
   OuterRadius: 600

--- a/src/app/simulation/MACE/SimPTS/scripts/SimPTS.yaml
+++ b/src/app/simulation/MACE/SimPTS/scripts/SimPTS.yaml
@@ -16,7 +16,7 @@ Accelerator:
 ECALField:
   Radius: 560
   Length: 1000
-  FastField: 0.0001
+  NominalField: 0.0001
 ECALMagnet:
   InnerRadius: 500
   OuterRadius: 550
@@ -49,7 +49,7 @@ MMSBeamPipe:
 MMSField:
   Radius: 610
   Length: 2200
-  FastField: 9.9999999999999991e-05
+  NominalField: 9.9999999999999991e-05
 MMSMagnet:
   InnerRadius: 550
   OuterRadius: 600
@@ -79,7 +79,7 @@ Solenoid:
   ReferenceCoilSpacing: 30
   FieldRadius: 131
   MaterialName: G4_Cu
-  FastField: 9.9999999999999991e-05
+  NominalField: 9.9999999999999991e-05
 VirtualDetectorA:
   Thickness: 1.0000000000000002e-06
 VirtualDetectorB:

--- a/src/app/simulation/MACE/SimTTC/scripts/SimTTC.yaml
+++ b/src/app/simulation/MACE/SimTTC/scripts/SimTTC.yaml
@@ -1,4 +1,4 @@
 MMSField:
   Radius: 610
   Length: 2200
-  FastField: 0.1
+  NominalField: 0.0001

--- a/src/lib/detector/MACE/Detector/Description/ECALField.c++
+++ b/src/lib/detector/MACE/Detector/Description/ECALField.c++
@@ -34,7 +34,7 @@ ECALField::ECALField() : // clang-format off
     fRadius{60_cm},
     fLength{100_cm},
     // Field
-    fFastField{0.1_T} {}
+    fNominalField{0.1_T} {}
 
 auto ECALField::Center() const -> muc::array3d {
     using namespace Mustard::VectorArithmeticOperator;
@@ -47,7 +47,7 @@ auto ECALField::ImportAllValue(const YAML::Node& node) -> void {
     ImportValue(node, fRadius, "Radius");
     ImportValue(node, fLength, "Length");
     // Field
-    ImportValue(node, fFastField, "NominalField");
+    ImportValue(node, fNominalField, "NominalField");
 }
 
 auto ECALField::ExportAllValue(YAML::Node& node) const -> void {
@@ -55,7 +55,7 @@ auto ECALField::ExportAllValue(YAML::Node& node) const -> void {
     ExportValue(node, fRadius, "Radius");
     ExportValue(node, fLength, "Length");
     // Field
-    ExportValue(node, fFastField, "NominalField");
+    ExportValue(node, fNominalField, "NominalField");
 }
 
 } // namespace MACE::Detector::Description

--- a/src/lib/detector/MACE/Detector/Description/ECALField.c++
+++ b/src/lib/detector/MACE/Detector/Description/ECALField.c++
@@ -47,7 +47,7 @@ auto ECALField::ImportAllValue(const YAML::Node& node) -> void {
     ImportValue(node, fRadius, "Radius");
     ImportValue(node, fLength, "Length");
     // Field
-    ImportValue(node, fFastField, "FastField");
+    ImportValue(node, fFastField, "NominalField");
 }
 
 auto ECALField::ExportAllValue(YAML::Node& node) const -> void {
@@ -55,7 +55,7 @@ auto ECALField::ExportAllValue(YAML::Node& node) const -> void {
     ExportValue(node, fRadius, "Radius");
     ExportValue(node, fLength, "Length");
     // Field
-    ExportValue(node, fFastField, "FastField");
+    ExportValue(node, fFastField, "NominalField");
 }
 
 } // namespace MACE::Detector::Description

--- a/src/lib/detector/MACE/Detector/Description/ECALField.h++
+++ b/src/lib/detector/MACE/Detector/Description/ECALField.h++
@@ -51,9 +51,9 @@ public:
     // Field
     ///////////////////////////////////////////////////////////
 
-    auto FastField() const -> auto { return fFastField; }
+    auto NominalField() const -> auto { return fFastField; }
 
-    auto FastField(double val) -> void { fFastField = val; }
+    auto NominalField(double val) -> void { fFastField = val; }
 
 private:
     auto ImportAllValue(const YAML::Node& node) -> void override;

--- a/src/lib/detector/MACE/Detector/Description/ECALField.h++
+++ b/src/lib/detector/MACE/Detector/Description/ECALField.h++
@@ -51,9 +51,9 @@ public:
     // Field
     ///////////////////////////////////////////////////////////
 
-    auto NominalField() const -> auto { return fFastField; }
+    auto NominalField() const -> auto { return fNominalField; }
 
-    auto NominalField(double val) -> void { fFastField = val; }
+    auto NominalField(double val) -> void { fNominalField = val; }
 
 private:
     auto ImportAllValue(const YAML::Node& node) -> void override;
@@ -71,7 +71,7 @@ private:
     // Field
     ///////////////////////////////////////////////////////////
 
-    double fFastField;
+    double fNominalField;
 };
 
 } // namespace MACE::Detector::Description

--- a/src/lib/detector/MACE/Detector/Description/MMSField.c++
+++ b/src/lib/detector/MACE/Detector/Description/MMSField.c++
@@ -32,14 +32,14 @@ MMSField::MMSField() :
     fRadius{65_cm},
     fLength{220_cm},
     // Field
-    fFastField{100_mT} {}
+    fNominalField{100_mT} {}
 
 void MMSField::ImportAllValue(const YAML::Node& node) {
     // Geometry
     ImportValue(node, fRadius, "Radius");
     ImportValue(node, fLength, "Length");
     // Field
-    ImportValue(node, fFastField, "NominalField");
+    ImportValue(node, fNominalField, "NominalField");
 }
 
 void MMSField::ExportAllValue(YAML::Node& node) const {
@@ -47,7 +47,7 @@ void MMSField::ExportAllValue(YAML::Node& node) const {
     ExportValue(node, fRadius, "Radius");
     ExportValue(node, fLength, "Length");
     // Field
-    ExportValue(node, fFastField, "NominalField");
+    ExportValue(node, fNominalField, "NominalField");
 }
 
 } // namespace MACE::Detector::Description

--- a/src/lib/detector/MACE/Detector/Description/MMSField.c++
+++ b/src/lib/detector/MACE/Detector/Description/MMSField.c++
@@ -39,7 +39,7 @@ void MMSField::ImportAllValue(const YAML::Node& node) {
     ImportValue(node, fRadius, "Radius");
     ImportValue(node, fLength, "Length");
     // Field
-    ImportValue(node, fFastField, "FastField");
+    ImportValue(node, fFastField, "NominalField");
 }
 
 void MMSField::ExportAllValue(YAML::Node& node) const {
@@ -47,7 +47,7 @@ void MMSField::ExportAllValue(YAML::Node& node) const {
     ExportValue(node, fRadius, "Radius");
     ExportValue(node, fLength, "Length");
     // Field
-    ExportValue(node, fFastField, "FastField");
+    ExportValue(node, fFastField, "NominalField");
 }
 
 } // namespace MACE::Detector::Description

--- a/src/lib/detector/MACE/Detector/Description/MMSField.h++
+++ b/src/lib/detector/MACE/Detector/Description/MMSField.h++
@@ -45,9 +45,9 @@ public:
     // Field
     ///////////////////////////////////////////////////////////
 
-    auto FastField() const -> auto { return fFastField; }
+    auto NominalField() const -> auto { return fFastField; }
 
-    auto FastField(double v) -> void { fFastField = v; }
+    auto NominalField(double v) -> void { fFastField = v; }
 
 private:
     auto ImportAllValue(const YAML::Node& node) -> void override;

--- a/src/lib/detector/MACE/Detector/Description/MMSField.h++
+++ b/src/lib/detector/MACE/Detector/Description/MMSField.h++
@@ -45,9 +45,9 @@ public:
     // Field
     ///////////////////////////////////////////////////////////
 
-    auto NominalField() const -> auto { return fFastField; }
+    auto NominalField() const -> auto { return fNominalField; }
 
-    auto NominalField(double v) -> void { fFastField = v; }
+    auto NominalField(double v) -> void { fNominalField = v; }
 
 private:
     auto ImportAllValue(const YAML::Node& node) -> void override;
@@ -65,7 +65,7 @@ private:
     // Field
     ///////////////////////////////////////////////////////////
 
-    double fFastField;
+    double fNominalField;
 };
 
 } // namespace MACE::Detector::Description

--- a/src/lib/detector/MACE/Detector/Description/Solenoid.c++
+++ b/src/lib/detector/MACE/Detector/Description/Solenoid.c++
@@ -44,7 +44,7 @@ Solenoid::Solenoid() :
     // Material
     fMaterialName{"G4_Cu"},
     // Field
-    fFastField{100_mT} {}
+    fNominalField{100_mT} {}
 
 auto Solenoid::ImportAllValue(const YAML::Node& node) -> void {
     // Geometry
@@ -61,7 +61,7 @@ auto Solenoid::ImportAllValue(const YAML::Node& node) -> void {
     // Material
     ImportValue(node, fMaterialName, "MaterialName");
     // Field
-    ImportValue(node, fFastField, "NominalField");
+    ImportValue(node, fNominalField, "NominalField");
 }
 
 auto Solenoid::ExportAllValue(YAML::Node& node) const -> void {
@@ -79,7 +79,7 @@ auto Solenoid::ExportAllValue(YAML::Node& node) const -> void {
     // Material
     ExportValue(node, fMaterialName, "MaterialName");
     // Field
-    ExportValue(node, fFastField, "NominalField");
+    ExportValue(node, fNominalField, "NominalField");
 }
 
 } // namespace MACE::Detector::Description

--- a/src/lib/detector/MACE/Detector/Description/Solenoid.c++
+++ b/src/lib/detector/MACE/Detector/Description/Solenoid.c++
@@ -61,7 +61,7 @@ auto Solenoid::ImportAllValue(const YAML::Node& node) -> void {
     // Material
     ImportValue(node, fMaterialName, "MaterialName");
     // Field
-    ImportValue(node, fFastField, "FastField");
+    ImportValue(node, fFastField, "NominalField");
 }
 
 auto Solenoid::ExportAllValue(YAML::Node& node) const -> void {
@@ -79,7 +79,7 @@ auto Solenoid::ExportAllValue(YAML::Node& node) const -> void {
     // Material
     ExportValue(node, fMaterialName, "MaterialName");
     // Field
-    ExportValue(node, fFastField, "FastField");
+    ExportValue(node, fFastField, "NominalField");
 }
 
 } // namespace MACE::Detector::Description

--- a/src/lib/detector/MACE/Detector/Description/Solenoid.h++
+++ b/src/lib/detector/MACE/Detector/Description/Solenoid.h++
@@ -79,9 +79,9 @@ public:
 
     // Field
 
-    auto NominalField() const -> auto { return fFastField; }
+    auto NominalField() const -> auto { return fNominalField; }
 
-    auto NominalField(double val) -> void { fFastField = val; }
+    auto NominalField(double val) -> void { fNominalField = val; }
 
 private:
     auto ImportAllValue(const YAML::Node& node) -> void override;
@@ -107,7 +107,7 @@ private:
 
     // Field
 
-    double fFastField;
+    double fNominalField;
 };
 
 } // namespace MACE::Detector::Description

--- a/src/lib/detector/MACE/Detector/Description/Solenoid.h++
+++ b/src/lib/detector/MACE/Detector/Description/Solenoid.h++
@@ -79,9 +79,9 @@ public:
 
     // Field
 
-    auto FastField() const -> auto { return fFastField; }
+    auto NominalField() const -> auto { return fFastField; }
 
-    auto FastField(double val) -> void { fFastField = val; }
+    auto NominalField(double val) -> void { fFastField = val; }
 
 private:
     auto ImportAllValue(const YAML::Node& node) -> void override;

--- a/src/lib/detector/MACE/Detector/Field/AcceleratorField.c++
+++ b/src/lib/detector/MACE/Detector/Field/AcceleratorField.c++
@@ -33,8 +33,8 @@ AcceleratorField::AcceleratorField() : // clang-format off
     }
 }
 
-AcceleratorField::FastField::FastField() :
-    fB{Detector::Description::MMSField::Instance().FastField()} {
+AcceleratorField::NominalField::NominalField() :
+    fB{Detector::Description::MMSField::Instance().NominalField()} {
     const auto& accelerator{Description::Accelerator::Instance()};
     fZ0 = accelerator.MaxPotentialPosition();
     fE1 = -accelerator.MaxPotential() / accelerator.DecelerateFieldLength();

--- a/src/lib/detector/MACE/Detector/Field/AcceleratorField.h++
+++ b/src/lib/detector/MACE/Detector/Field/AcceleratorField.h++
@@ -39,9 +39,9 @@ public:
     auto BE(T x) const -> F<T> { return std::visit([&x](auto&& f) { return f.BE(x); }, fField); } // clang-format on
 
 private:
-    class FastField : public Mustard::Detector::Field::ElectromagneticFieldBase<FastField> {
+    class NominalField : public Mustard::Detector::Field::ElectromagneticFieldBase<NominalField> {
     public:
-        FastField();
+        NominalField();
 
         template<Mustard::Concept::NumericVector3D T>
         auto B(T) const -> T { return {0, 0, fB}; }
@@ -60,7 +60,7 @@ private:
     using FieldMap = Mustard::Detector::Field::ElectromagneticFieldMapSymmetryY<"NoCache">;
 
 private:
-    std::variant<FastField, FieldMap> fField;
+    std::variant<NominalField, FieldMap> fField;
 };
 
 } // namespace MACE::Detector::Field

--- a/src/lib/detector/MACE/Detector/Field/ECALField.c++
+++ b/src/lib/detector/MACE/Detector/Field/ECALField.c++
@@ -25,11 +25,11 @@ namespace MACE::Detector::Field {
 
 ECALField::ECALField() : // clang-format off
     MagneticFieldBase<ECALField>{}, // clang-format on
-    fField{FastField{{}}} {
+    fField{NominalField{{}}} {
     const auto& fieldOption{Detector::Description::FieldOption::Instance()};
     const auto& ecalField{Detector::Description::ECALField::Instance()};
     if (fieldOption.UseFast()) {
-        fField = FastField{0, 0, ecalField.FastField()};
+        fField = NominalField{0, 0, ecalField.NominalField()};
     } else {
         fField = FieldMap{fieldOption.ParsedFieldDataFilePath().generic_string(), "EMCField"};
     }

--- a/src/lib/detector/MACE/Detector/Field/ECALField.h++
+++ b/src/lib/detector/MACE/Detector/Field/ECALField.h++
@@ -36,11 +36,11 @@ public:
     auto B(T x) const -> T { return std::visit([&x](auto&& f) { return f.B(x); }, fField); } // clang-format on
 
 private:
-    using FastField = Mustard::Detector::Field::UniformMagneticField;
+    using NominalField = Mustard::Detector::Field::UniformMagneticField;
     using FieldMap = Mustard::Detector::Field::MagneticFieldMapSymmetryY<>;
 
 private:
-    std::variant<FastField, FieldMap> fField;
+    std::variant<NominalField, FieldMap> fField;
 };
 
 } // namespace MACE::Detector::Field

--- a/src/lib/detector/MACE/Detector/Field/MMSField.c++
+++ b/src/lib/detector/MACE/Detector/Field/MMSField.c++
@@ -25,11 +25,11 @@ namespace MACE::Detector::Field {
 
 MMSField::MMSField() :
     MagneticFieldBase<MMSField>{},
-    fField{FastField{{}}} {
+    fField{NominalField{{}}} {
     const auto& fieldOption{Detector::Description::FieldOption::Instance()};
     const auto& ecalField{Detector::Description::MMSField::Instance()};
     if (fieldOption.UseFast()) {
-        fField = FastField{0, 0, ecalField.FastField()};
+        fField = NominalField{0, 0, ecalField.NominalField()};
     } else {
         fField = FieldMap{fieldOption.ParsedFieldDataFilePath().generic_string(), "MMSField"};
     }

--- a/src/lib/detector/MACE/Detector/Field/MMSField.h++
+++ b/src/lib/detector/MACE/Detector/Field/MMSField.h++
@@ -32,7 +32,7 @@ namespace MACE::Detector::Field {
 
 class MMSField : public Mustard::Detector::Field::MagneticFieldBase<MMSField> {
 private:
-    using FastField = Mustard::Detector::Field::UniformMagneticField;
+    using NominalField = Mustard::Detector::Field::UniformMagneticField;
     using FieldMap = Mustard::Detector::Field::MagneticFieldMapSymmetryY<>;
 
 public:
@@ -42,7 +42,7 @@ public:
     auto B(T x) const -> T { return std::visit([&x](auto&& f) { return f.B(x); }, fField); } // clang-format on
 
 private:
-    std::variant<FastField, FieldMap> fField;
+    std::variant<NominalField, FieldMap> fField;
 };
 
 } // namespace MACE::Detector::Field

--- a/src/lib/detector/MACE/Detector/Field/SolenoidFieldS1.c++
+++ b/src/lib/detector/MACE/Detector/Field/SolenoidFieldS1.c++
@@ -25,11 +25,11 @@ namespace MACE::Detector::Field {
 
 SolenoidFieldS1::SolenoidFieldS1() : // clang-format off
     MagneticFieldBase<SolenoidFieldS1>{}, // clang-format on
-    fField{FastField{{}}} {
+    fField{NominalField{{}}} {
     const auto& fieldOption{Detector::Description::FieldOption::Instance()};
     const auto& solenoid{Detector::Description::Solenoid::Instance()};
     if (fieldOption.UseFast()) {
-        fField = FastField{0, 0, solenoid.FastField()};
+        fField = NominalField{0, 0, solenoid.NominalField()};
     } else {
         fField = FieldMap{fieldOption.ParsedFieldDataFilePath().generic_string(), "SolenoidFieldS1"};
     }

--- a/src/lib/detector/MACE/Detector/Field/SolenoidFieldS1.h++
+++ b/src/lib/detector/MACE/Detector/Field/SolenoidFieldS1.h++
@@ -36,11 +36,11 @@ public:
     auto B(T x) const -> T { return std::visit([&x](auto&& f) { return f.B(x); }, fField); } // clang-format on
 
 private:
-    using FastField = Mustard::Detector::Field::UniformMagneticField;
+    using NominalField = Mustard::Detector::Field::UniformMagneticField;
     using FieldMap = Mustard::Detector::Field::MagneticFieldMapSymmetryY<>;
 
 private:
-    std::variant<FastField, FieldMap> fField;
+    std::variant<NominalField, FieldMap> fField;
 };
 
 } // namespace MACE::Detector::Field

--- a/src/lib/detector/MACE/Detector/Field/SolenoidFieldS2.c++
+++ b/src/lib/detector/MACE/Detector/Field/SolenoidFieldS2.c++
@@ -25,11 +25,11 @@ namespace MACE::Detector::Field {
 
 SolenoidFieldS2::SolenoidFieldS2() : // clang-format off
     MagneticFieldBase<SolenoidFieldS2>{}, // clang-format on
-    fField{FastField{{}}} {
+    fField{NominalField{{}}} {
     const auto& fieldOption{Detector::Description::FieldOption::Instance()};
     const auto& solenoid{Detector::Description::Solenoid::Instance()};
     if (fieldOption.UseFast()) {
-        fField = FastField{solenoid.FastField(), 0, 0};
+        fField = NominalField{solenoid.NominalField(), 0, 0};
     } else {
         fField = FieldMap{fieldOption.ParsedFieldDataFilePath().generic_string(), "SolenoidFieldS2"};
     }

--- a/src/lib/detector/MACE/Detector/Field/SolenoidFieldS2.h++
+++ b/src/lib/detector/MACE/Detector/Field/SolenoidFieldS2.h++
@@ -36,11 +36,11 @@ public:
     auto B(T x) const -> T { return std::visit([&x](auto&& f) { return f.B(x); }, fField); } // clang-format on
 
 private:
-    using FastField = Mustard::Detector::Field::UniformMagneticField;
+    using NominalField = Mustard::Detector::Field::UniformMagneticField;
     using FieldMap = Mustard::Detector::Field::MagneticFieldMapSymmetryY<>;
 
 private:
-    std::variant<FastField, FieldMap> fField;
+    std::variant<NominalField, FieldMap> fField;
 };
 
 } // namespace MACE::Detector::Field

--- a/src/lib/detector/MACE/Detector/Field/SolenoidFieldS3.c++
+++ b/src/lib/detector/MACE/Detector/Field/SolenoidFieldS3.c++
@@ -25,11 +25,11 @@ namespace MACE::Detector::Field {
 
 SolenoidFieldS3::SolenoidFieldS3() : // clang-format off
     MagneticFieldBase<SolenoidFieldS3>{}, // clang-format on
-    fField{FastField{{}}} {
+    fField{NominalField{{}}} {
     const auto& fieldOption{Detector::Description::FieldOption::Instance()};
     const auto& solenoid{Detector::Description::Solenoid::Instance()};
     if (fieldOption.UseFast()) {
-        fField = FastField{0, 0, solenoid.FastField()};
+        fField = NominalField{0, 0, solenoid.NominalField()};
     } else {
         fField = FieldMap{fieldOption.ParsedFieldDataFilePath().generic_string(), "SolenoidFieldS3"};
     }

--- a/src/lib/detector/MACE/Detector/Field/SolenoidFieldS3.h++
+++ b/src/lib/detector/MACE/Detector/Field/SolenoidFieldS3.h++
@@ -36,11 +36,11 @@ public:
     auto B(T x) const -> T { return std::visit([&x](auto&& f) { return f.B(x); }, fField); } // clang-format on
 
 private:
-    using FastField = Mustard::Detector::Field::UniformMagneticField;
+    using NominalField = Mustard::Detector::Field::UniformMagneticField;
     using FieldMap = Mustard::Detector::Field::MagneticFieldMapSymmetryY<>;
 
 private:
-    std::variant<FastField, FieldMap> fField;
+    std::variant<NominalField, FieldMap> fField;
 };
 
 } // namespace MACE::Detector::Field

--- a/src/lib/detector/MACE/Detector/Field/SolenoidFieldT1.c++
+++ b/src/lib/detector/MACE/Detector/Field/SolenoidFieldT1.c++
@@ -25,11 +25,11 @@ namespace MACE::Detector::Field {
 
 SolenoidFieldT1::SolenoidFieldT1() : // clang-format off
     MagneticFieldBase<SolenoidFieldT1>{}, // clang-format on
-    fField{FastField{{}, {}, {}, {}}} {
+    fField{NominalField{{}, {}, {}, {}}} {
     const auto& fieldOption{Detector::Description::FieldOption::Instance()};
     const auto& solenoid{Detector::Description::Solenoid::Instance()};
     if (fieldOption.UseFast()) { // clang-format off
-        fField = FastField{solenoid.FastField(), solenoid.T1Radius(), solenoid.T1Center(), {0, 0, 1}}; // clang-format on
+        fField = NominalField{solenoid.NominalField(), solenoid.T1Radius(), solenoid.T1Center(), {0, 0, 1}}; // clang-format on
     } else {
         fField = FieldMap{fieldOption.ParsedFieldDataFilePath().generic_string(), "SolenoidFieldT1"};
     }

--- a/src/lib/detector/MACE/Detector/Field/SolenoidFieldT1.h++
+++ b/src/lib/detector/MACE/Detector/Field/SolenoidFieldT1.h++
@@ -36,11 +36,11 @@ public:
     auto B(T x) const -> T { return std::visit([&x](auto&& f) { return f.B(x); }, fField); } // clang-format on
 
 private:
-    using FastField = Mustard::Detector::Field::ToroidField;
+    using NominalField = Mustard::Detector::Field::ToroidField;
     using FieldMap = Mustard::Detector::Field::MagneticFieldMapSymmetryY<>;
 
 private:
-    std::variant<FastField, FieldMap> fField;
+    std::variant<NominalField, FieldMap> fField;
 };
 
 } // namespace MACE::Detector::Field

--- a/src/lib/detector/MACE/Detector/Field/SolenoidFieldT2.c++
+++ b/src/lib/detector/MACE/Detector/Field/SolenoidFieldT2.c++
@@ -25,11 +25,11 @@ namespace MACE::Detector::Field {
 
 SolenoidFieldT2::SolenoidFieldT2() : // clang-format off
     MagneticFieldBase<SolenoidFieldT2>{}, // clang-format on
-    fField{FastField{{}, {}, {}, {}}} {
+    fField{NominalField{{}, {}, {}, {}}} {
     const auto& fieldOption{Detector::Description::FieldOption::Instance()};
     const auto& solenoid{Detector::Description::Solenoid::Instance()};
     if (fieldOption.UseFast()) { // clang-format off
-        fField = FastField{solenoid.FastField(), solenoid.T2Radius(), solenoid.T2Center(), {0, 0, -1}}; // clang-format on
+        fField = NominalField{solenoid.NominalField(), solenoid.T2Radius(), solenoid.T2Center(), {0, 0, -1}}; // clang-format on
     } else {
         fField = FieldMap{fieldOption.ParsedFieldDataFilePath().generic_string(), "SolenoidFieldT2"};
     }

--- a/src/lib/detector/MACE/Detector/Field/SolenoidFieldT2.h++
+++ b/src/lib/detector/MACE/Detector/Field/SolenoidFieldT2.h++
@@ -36,11 +36,11 @@ public:
     auto B(T x) const -> T { return std::visit([&x](auto&& f) { return f.B(x); }, fField); } // clang-format on
 
 private:
-    using FastField = Mustard::Detector::Field::ToroidField;
+    using NominalField = Mustard::Detector::Field::ToroidField;
     using FieldMap = Mustard::Detector::Field::MagneticFieldMapSymmetryY<>;
 
 private:
-    std::variant<FastField, FieldMap> fField;
+    std::variant<NominalField, FieldMap> fField;
 };
 
 } // namespace MACE::Detector::Field

--- a/src/lib/reconstruction/MACE/Reconstruction/MMSTracking/Finder/TruthFinder.inl
+++ b/src/lib/reconstruction/MACE/Reconstruction/MMSTracking/Finder/TruthFinder.inl
@@ -100,7 +100,7 @@ auto TruthFinder<AHit, ATrack>::operator()(const std::vector<AHitPointer>& hitDa
         Get<"x0">(*seed) = Get<"x0">(firstHit);
         Get<"Ek0">(*seed) = Get<"Ek0">(firstHit);
         Get<"p0">(*seed) = Get<"p0">(firstHit);
-        Data::CalculateHelix(*seed, Detector::Description::MMSField::Instance().FastField());
+        Data::CalculateHelix(*seed, Detector::Description::MMSField::Instance().NominalField());
         Get<"CreatProc">(*seed) = Get<"CreatProc">(firstHit);
     }
 

--- a/src/lib/reconstruction/MACE/Reconstruction/MMSTracking/Fitter/GenFitterBase.inl
+++ b/src/lib/reconstruction/MACE/Reconstruction/MMSTracking/Fitter/GenFitterBase.inl
@@ -193,7 +193,7 @@ auto GenFitterBase<AHit, ATrack, AFitter>::Finalize(std::shared_ptr<genfit::Trac
     Get<"x0">(*track) = this->template FromTVector3<muc::array3d>(x0);
     Get<"Ek0">(*track) = ek0;
     Get<"p0">(*track) = this->template FromTVector3<muc::array3d>(p0);
-    Data::CalculateHelix(*track, Detector::Description::MMSField::Instance().FastField());
+    Data::CalculateHelix(*track, Detector::Description::MMSField::Instance().NominalField());
 
     if (fEnableEventDisplay) {
         genfit::EventDisplay::getInstance()->addEvent(genfitTrack.get());

--- a/src/lib/reconstruction/MACE/Reconstruction/MMSTracking/Fitter/TruthFitter.inl
+++ b/src/lib/reconstruction/MACE/Reconstruction/MMSTracking/Fitter/TruthFitter.inl
@@ -40,7 +40,7 @@ auto TruthFitter<AHit, ATrack>::operator()(const std::vector<AHitPointer>& hitDa
     Get<"x0">(*track) = Get<"x0">(firstHit);
     Get<"Ek0">(*track) = Get<"Ek0">(firstHit);
     Get<"p0">(*track) = Get<"p0">(firstHit);
-    Data::CalculateHelix(*track, Detector::Description::MMSField::Instance().FastField());
+    Data::CalculateHelix(*track, Detector::Description::MMSField::Instance().NominalField());
     Get<"CreatProc">(*track) = Get<"CreatProc">(firstHit);
 
     if (not fCheckHitDataConsistency) {


### PR DESCRIPTION
## Summary
This pull request standardizes the naming of magnetic field parameters across the codebase from `FastField` to `NominalField`.

**Magnetic field parameter renaming:**

* Renamed all instances of the magnetic field parameter from `FastField` to `NominalField` in YAML configuration files for simulation and detector descriptions. [[1]](diffhunk://#diff-b20d53e8b3a3323e533ed6ac09b745ab65d835bdf0ce6d1407679eb421b5e419L90-R90) [[2]](diffhunk://#diff-b20d53e8b3a3323e533ed6ac09b745ab65d835bdf0ce6d1407679eb421b5e419L124-R124) [[3]](diffhunk://#diff-b20d53e8b3a3323e533ed6ac09b745ab65d835bdf0ce6d1407679eb421b5e419L154-R154) [[4]](diffhunk://#diff-ff709a0be91446163251b5f4952e3d35d6bc906159c460ec7a605d9e0de1d48bL38-R38) [[5]](diffhunk://#diff-591a55634e0c37021d50776eef82273cbf0b5b6cf9eef5775a14da07223cf59bL19-R19) [[6]](diffhunk://#diff-591a55634e0c37021d50776eef82273cbf0b5b6cf9eef5775a14da07223cf59bL52-R52) [[7]](diffhunk://#diff-591a55634e0c37021d50776eef82273cbf0b5b6cf9eef5775a14da07223cf59bL82-R82) [[8]](diffhunk://#diff-ab161ca315a58fada1f4f85d98efd93f054a8bd46d2da1908187c5a9c646adfaL4-R4)
* Updated all relevant C++ classes and methods to use `NominalField` instead of `FastField`, including field import/export, class member names, and method names in `ECALField`, `MMSField`, `Solenoid`, and related field classes. [[1]](diffhunk://#diff-f468c8e187f058646a4312f97e5e5d97f694b0aa7c0439687c3b3114d6c92410L50-R58) [[2]](diffhunk://#diff-54fbea9e45e83c4f472d2b2717d2d5249b47499f2798303469d3f8096800fd3bL54-R56) [[3]](diffhunk://#diff-b4c000e8130794a92bde2bcb1fdb53c06e620a4eb97f00d905910e90900140b1L42-R50) [[4]](diffhunk://#diff-da58e9fb8aa134be1c106ae9571c00b81035bd6b61e186cc08943f1816d08c26L48-R50) [[5]](diffhunk://#diff-4ca7f880230f8914d619d4e47bcefd20704d9bd3cb0758ea1dc567c06090c75eL64-R64) [[6]](diffhunk://#diff-4ca7f880230f8914d619d4e47bcefd20704d9bd3cb0758ea1dc567c06090c75eL82-R82) [[7]](diffhunk://#diff-7df52885db737af39d3011e9af57669f02ed7e820288fc978d2d388311fd9ae5L82-R84) [[8]](diffhunk://#diff-a8664c6bd16b10917f96db2035e1660b4e78a03a42841048c85662bca11475d0L36-R37) [[9]](diffhunk://#diff-3356030ee4c306dbef4d3291abd6d18379efa0c9ebc721d3d6e87a2d6e6db3ddL42-R44) [[10]](diffhunk://#diff-3356030ee4c306dbef4d3291abd6d18379efa0c9ebc721d3d6e87a2d6e6db3ddL63-R63) [[11]](diffhunk://#diff-8a12e45085f4ab9f03b2392b1f00f852c503ac3c866c6b94c390b88879928ebaL28-R32) [[12]](diffhunk://#diff-449d8c319d5560a749b65336916c7ce98e59a1d3d363c252f36ddf4479c0155aL39-R43)
* Updated generator and simulation logic to use the new `NominalField` accessor instead of `FastField` for magnetic field values in relevant C++ files. [[1]](diffhunk://#diff-96141ceb9cb7808880078ac81a4a68f82f74e7e456283d219d287d327fc9e54eL79-R79) [[2]](diffhunk://#diff-de5c3538215f8142d501e42399cceabe3009b7050ca2935d7fa01b1f6528891dL82-R82)

## Type of change
- Refactor (non-breaking change which optimizes code structure)

## Checklist before requesting review
- [x] I have read the [contributing guidelines](https://github.com/zhao-shihan/MACESW/blob/main/CONTRIBUTING.md)
- [x] The PR targets the `main` branch.
- [x] I linked related issues and provided context in the PR description.
- [x] My code follows the [coding style guide](https://github.com/zhao-shihan/MACESW/blob/main/STYLE_GUIDE.md) and linting rules.
- [x] I added/updated unit tests where applicable.
- [x] I updated relevant documentation (README, Doxygen, or design docs) where applicable.
- [x] I ran the test-suite locally and all tests pass if applicable.
- [x] All CI checks pass.
