### PR TITLE
Remove regression test badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,6 @@
 [![Build (AMD64 GNU/Linux Clang, unity build)](https://github.com/zhao-shihan/MACESW/actions/workflows/build-with-clang.yml/badge.svg)](https://github.com/zhao-shihan/MACESW/actions/workflows/build-with-clang.yml)
 [![Static code analysis](https://github.com/zhao-shihan/MACESW/actions/workflows/static-code-analysis.yml/badge.svg)](https://github.com/zhao-shihan/MACESW/actions/workflows/static-code-analysis.yml)
 
-[![Regression test (AMD64 GNU/Linux GCC)](https://github.com/zhao-shihan/MACESW/actions/workflows/regression-test-with-gcc.yml/badge.svg)](https://github.com/zhao-shihan/MACESW/actions/workflows/regression-test-with-gcc.yml)
-[![Regression test (AMD64 GNU/Linux Clang, unity build)](https://github.com/zhao-shihan/MACESW/actions/workflows/regression-test-with-clang.yml/badge.svg)](https://github.com/zhao-shihan/MACESW/actions/workflows/regression-test-with-clang.yml)
-
 <!--
   The align attribute on img is obsolete in HTML5, but is used here because
   GitHub strips inline styles from README.md. This is the only way to right-align


### PR DESCRIPTION
This pull request removes the regression test status badges for GCC and Clang from the `README.md` file. The badges are no longer displayed at the top of the README, which may indicate these workflows are being deprecated or are no longer relevant.
Reference : https://github.com/zhao-shihan/MACESW/pull/78#issuecomment-4314502937